### PR TITLE
v1.2.0 — 集成测试 + 软删除 + API 版本化

### DIFF
--- a/src/main/java/com/cn/cloudpictureplatform/config/SecurityConfig.java
+++ b/src/main/java/com/cn/cloudpictureplatform/config/SecurityConfig.java
@@ -35,13 +35,13 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/register", "/api/auth/login", "/actuator/health").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/pictures/public").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/pictures/search").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/pictures/recommendations").permitAll()
+                        .requestMatchers("/api/v1/auth/register", "/api/v1/auth/login", "/actuator/health").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/pictures/public").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/pictures/search").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/pictures/recommendations").permitAll()
                         .requestMatchers(HttpMethod.GET, "/uploads/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
-                        .requestMatchers("/api/admin/**").hasAuthority("admin:review")
+                        .requestMatchers("/api/v1/admin/**").hasAuthority("admin:review")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/cn/cloudpictureplatform/domain/picture/PictureAsset.java
+++ b/src/main/java/com/cn/cloudpictureplatform/domain/picture/PictureAsset.java
@@ -3,6 +3,7 @@ package com.cn.cloudpictureplatform.domain.picture;
 import com.cn.cloudpictureplatform.common.exception.ApiException;
 import com.cn.cloudpictureplatform.common.model.BaseEntity;
 import com.cn.cloudpictureplatform.common.web.ApiErrorCode;
+import java.time.Instant;
 import java.util.UUID;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -73,6 +74,12 @@ public class PictureAsset extends BaseEntity {
     @Column
     private Integer height;
 
+    @Column(name = "deleted_at")
+    private Instant deletedAt;
+
+    @Column(name = "deleted_by", columnDefinition = "uuid")
+    private UUID deletedBy;
+
     // ── Aggregate Root 业务方法 ──────────────────────────────
 
     public void changeVisibility(Visibility newVisibility) {
@@ -136,5 +143,19 @@ public class PictureAsset extends BaseEntity {
         if (newName != null && !newName.isBlank()) {
             this.name = newName.trim();
         }
+    }
+
+    public void softDelete(UUID deletedBy) {
+        this.deletedAt = Instant.now();
+        this.deletedBy = deletedBy;
+    }
+
+    public boolean isDeleted() {
+        return this.deletedAt != null;
+    }
+
+    public void restore() {
+        this.deletedAt = null;
+        this.deletedBy = null;
     }
 }

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminAiController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminAiController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/admin/ai")
+@RequestMapping("/api/v1/admin/ai")
 @RequiredArgsConstructor
 public class AdminAiController {
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminPermissionController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminPermissionController.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 
 @Validated
 @RestController
-@RequestMapping("/api/admin/permissions")
+@RequestMapping("/api/v1/admin/permissions")
 @RequiredArgsConstructor
 public class AdminPermissionController {
     private final PermissionService permissionService;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminPictureController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminPictureController.java
@@ -32,7 +32,7 @@ import com.cn.cloudpictureplatform.application.shared.dto.PictureResponse;
 
 @Validated
 @RestController
-@RequestMapping("/api/admin/pictures")
+@RequestMapping("/api/v1/admin/pictures")
 public class AdminPictureController {
     private final ModerationService moderationService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminRoleController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminRoleController.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 
 @Validated
 @RestController
-@RequestMapping("/api/admin/roles")
+@RequestMapping("/api/v1/admin/roles")
 @RequiredArgsConstructor
 public class AdminRoleController {
     private final RoleService roleService;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminUserController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminUserController.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 @Validated
 @RestController
-@RequestMapping("/api/admin/users")
+@RequestMapping("/api/v1/admin/users")
 @RequiredArgsConstructor
 public class AdminUserController {
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminUserRoleController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminUserRoleController.java
@@ -19,7 +19,7 @@ import com.cn.cloudpictureplatform.application.shared.dto.UserRoleResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/api/admin/users/{userId}/roles")
+@RequestMapping("/api/v1/admin/users/{userId}/roles")
 @RequiredArgsConstructor
 public class AdminUserRoleController {
     private final UserRoleService userRoleService;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/SearchAdminController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/SearchAdminController.java
@@ -13,7 +13,7 @@ import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.interfaces.admin.dto.SearchReindexResponse;
 
 @RestController
-@RequestMapping("/api/admin/search")
+@RequestMapping("/api/v1/admin/search")
 public class SearchAdminController {
     private final SearchMaintenanceService searchMaintenanceService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/ai/AiAssistantController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/ai/AiAssistantController.java
@@ -13,7 +13,7 @@ import com.cn.cloudpictureplatform.infrastructure.ai.gateway.AiGateway;
 import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
 
 @RestController
-@RequestMapping("/api/ai")
+@RequestMapping("/api/v1/ai")
 @ConditionalOnBean(AiGateway.class)
 public class AiAssistantController {
     private final AiGateway aiGateway;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/album/AlbumController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/album/AlbumController.java
@@ -18,7 +18,7 @@ import com.cn.cloudpictureplatform.interfaces.album.dto.AlbumCreateRequest;
 import com.cn.cloudpictureplatform.interfaces.album.dto.AlbumResponse;
 
 @RestController
-@RequestMapping("/api/albums")
+@RequestMapping("/api/v1/albums")
 public class AlbumController {
     private final AlbumService albumService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/auth/AuthController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/auth/AuthController.java
@@ -20,7 +20,7 @@ import com.cn.cloudpictureplatform.application.auth.dto.RegisterRequest;
 import com.cn.cloudpictureplatform.application.auth.dto.UserProfileUpdateRequest;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/api/v1/auth")
 public class AuthController {
     private final AuthService authService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/developer/DeveloperController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/developer/DeveloperController.java
@@ -18,7 +18,7 @@ import com.cn.cloudpictureplatform.domain.apikey.ApiKey;
 import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
 
 @RestController
-@RequestMapping("/api/developer/keys")
+@RequestMapping("/api/v1/developer/keys")
 public class DeveloperController {
     private final ApiKeyService apiKeyService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/excalidraw/ExcalidrawSceneController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/excalidraw/ExcalidrawSceneController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/scenes")
+@RequestMapping("/api/v1/scenes")
 @RequiredArgsConstructor
 public class ExcalidrawSceneController {
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/notification/NotificationController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/notification/NotificationController.java
@@ -17,7 +17,7 @@ import com.cn.cloudpictureplatform.domain.notification.NotificationRecord;
 import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
 
 @RestController
-@RequestMapping("/api/notifications")
+@RequestMapping("/api/v1/notifications")
 public class NotificationController {
 
     private final NotificationService notificationService;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/BatchPictureController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/BatchPictureController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/pictures/batch")
+@RequestMapping("/api/v1/pictures/batch")
 @RequiredArgsConstructor
 public class BatchPictureController {
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/DeduplicationPictureController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/DeduplicationPictureController.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 @Slf4j
 @Validated
 @RestController
-@RequestMapping("/api/pictures")
+@RequestMapping("/api/v1/pictures")
 @RequiredArgsConstructor
 public class DeduplicationPictureController {
     private final DeduplicationPictureUploadService deduplicationUploadService;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/ImageSearchController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/ImageSearchController.java
@@ -10,7 +10,7 @@ import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.common.web.PageResponse;
 
 @RestController
-@RequestMapping("/api/search")
+@RequestMapping("/api/v1/search")
 public class ImageSearchController {
     private final HybridSearchService hybridSearchService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureCommentController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureCommentController.java
@@ -19,7 +19,7 @@ import com.cn.cloudpictureplatform.interfaces.picture.dto.CommentCreateRequest;
 import com.cn.cloudpictureplatform.interfaces.picture.dto.CommentResponse;
 
 @RestController
-@RequestMapping("/api/pictures/{pictureId}/comments")
+@RequestMapping("/api/v1/pictures/{pictureId}/comments")
 public class PictureCommentController {
     private final PictureCommentService pictureCommentService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureController.java
@@ -50,7 +50,7 @@ import lombok.RequiredArgsConstructor;
 
 @Validated
 @RestController
-@RequestMapping("/api/pictures")
+@RequestMapping("/api/v1/pictures")
 @RequiredArgsConstructor
 public class PictureController {
     private static final String SESSION_CONTRACT_VERSION = "picture-editor-session.v1";

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureVersionController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureVersionController.java
@@ -15,7 +15,7 @@ import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.interfaces.picture.dto.PictureVersionResponse;
 
 @RestController
-@RequestMapping("/api/pictures/{pictureId}/versions")
+@RequestMapping("/api/v1/pictures/{pictureId}/versions")
 public class PictureVersionController {
     private final PictureVersionService pictureVersionService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/space/SpaceController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/space/SpaceController.java
@@ -12,7 +12,7 @@ import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
 
 @RestController
-@RequestMapping("/api/spaces")
+@RequestMapping("/api/v1/spaces")
 public class SpaceController {
     private final SpaceQuotaService spaceQuotaService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/tag/TagController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/tag/TagController.java
@@ -23,7 +23,7 @@ import com.cn.cloudpictureplatform.application.tag.dto.TagUpdateRequest;
 
 @Validated
 @RestController
-@RequestMapping("/api/tags")
+@RequestMapping("/api/v1/tags")
 public class TagController {
     private final TagService tagService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/team/TeamActivityController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/team/TeamActivityController.java
@@ -12,7 +12,7 @@ import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.common.web.PageResponse;
 
 @RestController
-@RequestMapping("/api/teams/{teamId}/activities")
+@RequestMapping("/api/v1/teams/{teamId}/activities")
 public class TeamActivityController {
     private final TeamActivityService teamActivityService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/team/TeamController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/team/TeamController.java
@@ -40,7 +40,7 @@ import com.cn.cloudpictureplatform.application.team.dto.TeamUpdateRequest;
 
 @Validated
 @RestController
-@RequestMapping("/api/teams")
+@RequestMapping("/api/v1/teams")
 public class TeamController {
     private final TeamQueryService teamQueryService;
     private final TeamCommandService teamCommandService;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/watermark/WatermarkController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/watermark/WatermarkController.java
@@ -20,7 +20,7 @@ import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.interfaces.watermark.dto.WatermarkConfigRequest;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/v1")
 public class WatermarkController {
     private final WatermarkService watermarkService;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/webhook/WebhookController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/webhook/WebhookController.java
@@ -20,7 +20,7 @@ import com.cn.cloudpictureplatform.domain.webhook.WebhookEndpoint;
 import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
 
 @RestController
-@RequestMapping("/api/webhooks")
+@RequestMapping("/api/v1/webhooks")
 public class WebhookController {
     private final WebhookService webhookService;
 

--- a/src/main/resources/db/migration/V33__add_soft_delete_to_picture.sql
+++ b/src/main/resources/db/migration/V33__add_soft_delete_to_picture.sql
@@ -1,0 +1,5 @@
+-- V33: Add soft delete support to picture_asset
+ALTER TABLE picture_asset ADD COLUMN deleted_at TIMESTAMPTZ;
+ALTER TABLE picture_asset ADD COLUMN deleted_by UUID;
+
+CREATE INDEX idx_picture_deleted_at ON picture_asset(deleted_at) WHERE deleted_at IS NOT NULL;

--- a/src/test/java/com/cn/cloudpictureplatform/application/picture/PictureUploadIntegrationTest.java
+++ b/src/test/java/com/cn/cloudpictureplatform/application/picture/PictureUploadIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.cn.cloudpictureplatform.application.picture;
+
+import com.cn.cloudpictureplatform.domain.picture.PictureAsset;
+import com.cn.cloudpictureplatform.domain.picture.ReviewStatus;
+import com.cn.cloudpictureplatform.domain.picture.Visibility;
+import com.cn.cloudpictureplatform.domain.space.Space;
+import com.cn.cloudpictureplatform.domain.space.SpaceType;
+import com.cn.cloudpictureplatform.domain.user.AppUser;
+import com.cn.cloudpictureplatform.domain.user.UserStatus;
+import com.cn.cloudpictureplatform.infrastructure.persistence.AppUserRepository;
+import com.cn.cloudpictureplatform.infrastructure.persistence.PictureAssetRepository;
+import com.cn.cloudpictureplatform.infrastructure.persistence.SpaceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("dev")
+@Transactional
+class PictureUploadIntegrationTest {
+
+    @Autowired
+    private PictureUploadService pictureUploadService;
+
+    @Autowired
+    private DeduplicationPictureUploadService deduplicationPictureUploadService;
+
+    @Autowired
+    private AppUserRepository appUserRepository;
+
+    @Autowired
+    private PictureAssetRepository pictureAssetRepository;
+
+    @Autowired
+    private SpaceRepository spaceRepository;
+
+    private AppUser testUser;
+    private UUID spaceId;
+
+    @BeforeEach
+    void setUp() {
+        testUser = AppUser.builder()
+                .username("upload-test-" + UUID.randomUUID().toString().substring(0, 8))
+                .email("upload-" + UUID.randomUUID().toString().substring(0, 8) + "@test.com")
+                .passwordHash("$2a$10$dummy")
+                .displayName("Upload Test User")
+                .status(UserStatus.ACTIVE)
+                .build();
+        testUser = appUserRepository.save(testUser);
+
+        Space space = spaceRepository.findFirstByOwnerIdAndType(testUser.getId(), SpaceType.PERSONAL)
+                .orElseGet(() -> spaceRepository.save(Space.builder()
+                        .ownerId(testUser.getId())
+                        .type(SpaceType.PERSONAL)
+                        .name("Personal")
+                        .quotaBytes(10L * 1024 * 1024 * 1024)
+                        .usedBytes(0L)
+                        .build()));
+        spaceId = space.getId();
+    }
+
+    @Test
+    void shouldUploadPictureSuccessfully() {
+        byte[] imageBytes = createTestImageBytes();
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "test.jpg", "image/jpeg", imageBytes);
+
+        var response = pictureUploadService.upload(
+                testUser.getId(), file, Visibility.PRIVATE, "Test Picture", null);
+
+        assertNotNull(response);
+        assertNotNull(response.getId());
+
+        var saved = pictureAssetRepository.findById(response.getId());
+        assertTrue(saved.isPresent());
+        assertEquals("Test Picture", saved.get().getName());
+        assertEquals(Visibility.PRIVATE, saved.get().getVisibility());
+        assertEquals(ReviewStatus.APPROVED, saved.get().getReviewStatus());
+        assertEquals(testUser.getId(), saved.get().getOwnerId());
+    }
+
+    @Test
+    void shouldSetPendingReviewForPublicUpload() {
+        byte[] imageBytes = createTestImageBytes();
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "public.jpg", "image/jpeg", imageBytes);
+
+        var response = pictureUploadService.upload(
+                testUser.getId(), file, Visibility.PUBLIC, "Public Picture", null);
+
+        var saved = pictureAssetRepository.findById(response.getId()).orElseThrow();
+        assertEquals(Visibility.PUBLIC, saved.getVisibility());
+        assertEquals(ReviewStatus.PENDING, saved.getReviewStatus());
+    }
+
+    @Test
+    void shouldDedupIdenticalFiles() {
+        byte[] imageBytes = createTestImageBytes();
+        MockMultipartFile file1 = new MockMultipartFile(
+                "file", "test1.jpg", "image/jpeg", imageBytes);
+        MockMultipartFile file2 = new MockMultipartFile(
+                "file", "test2.jpg", "image/jpeg", imageBytes);
+
+        var response1 = deduplicationPictureUploadService.uploadWithDeduplication(
+                testUser.getId(), file1, Visibility.PRIVATE, "Picture 1", null);
+        var response2 = deduplicationPictureUploadService.uploadWithDeduplication(
+                testUser.getId(), file2, Visibility.PRIVATE, "Picture 2", null);
+
+        assertNotNull(response1);
+        assertNotNull(response2);
+        assertNotEquals(response1.getId(), response2.getId());
+
+        var pic1 = pictureAssetRepository.findById(response1.getId()).orElseThrow();
+        var pic2 = pictureAssetRepository.findById(response2.getId()).orElseThrow();
+        assertEquals(pic1.getFileContentId(), pic2.getFileContentId());
+    }
+
+    @Test
+    void shouldRejectEmptyFile() {
+        MockMultipartFile emptyFile = new MockMultipartFile(
+                "file", "empty.jpg", "image/jpeg", new byte[0]);
+
+        assertThrows(Exception.class, () ->
+                pictureUploadService.upload(
+                        testUser.getId(), emptyFile, Visibility.PRIVATE, "Empty", null));
+    }
+
+    private byte[] createTestImageBytes() {
+        return new byte[]{
+                (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0,
+                0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+                0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+                (byte) 0xFF, (byte) 0xD9
+        };
+    }
+}


### PR DESCRIPTION
## 改动
- 29 files changed, +200 / -30 lines
- 26 tests passing (22 unit + 4 integration)

### P1-16: 集成测试
PictureUploadIntegrationTest — 4 个测试覆盖核心上传流程

### P2-21: 软删除
PictureAsset 新增 deletedAt/deletedBy + softDelete/restore/isDeleted
V33 迁移添加列和部分索引

### P2-22: API 版本化
全部 25 个控制器 + SecurityConfig: /api/ → /api/v1/

Closes #22