### PR TITLE
v1.4.0 — 架构违规清零

### DIFF
--- a/src/main/java/com/cn/cloudpictureplatform/application/auth/AuthService.java
+++ b/src/main/java/com/cn/cloudpictureplatform/application/auth/AuthService.java
@@ -27,7 +27,7 @@ import com.cn.cloudpictureplatform.infrastructure.persistence.RolePermissionRepo
 import com.cn.cloudpictureplatform.infrastructure.persistence.RoleRepository;
 import com.cn.cloudpictureplatform.infrastructure.persistence.SpaceRepository;
 import com.cn.cloudpictureplatform.infrastructure.persistence.UserRoleRepository;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.infrastructure.security.JwtTokenService;
 import com.cn.cloudpictureplatform.application.shared.dto.AuthResponse;
 import com.cn.cloudpictureplatform.application.shared.dto.LoginResponse;

--- a/src/main/java/com/cn/cloudpictureplatform/application/notification/NotificationPort.java
+++ b/src/main/java/com/cn/cloudpictureplatform/application/notification/NotificationPort.java
@@ -1,0 +1,19 @@
+package com.cn.cloudpictureplatform.application.notification;
+
+import java.util.Collection;
+import java.util.UUID;
+
+public interface NotificationPort {
+
+    void notifyUploadCompleted(String username, UUID pictureId, String pictureName);
+
+    void notifyReviewDecision(String ownerUsername, UUID pictureId, String pictureName, boolean approved, String reason);
+
+    void notifyAdminNewUpload(UUID pictureId, String pictureName, String uploaderUsername);
+
+    void notifyTeamInvite(String inviteeUsername, UUID teamId, String teamName, String inviterUsername);
+
+    void notifyTeamPictureUploaded(Collection<String> usernames, UUID pictureId, String pictureName, String uploaderUsername);
+
+    void notifyTeamMemberJoined(String username, UUID teamId, String teamName);
+}

--- a/src/main/java/com/cn/cloudpictureplatform/application/outbox/OutboxProcessor.java
+++ b/src/main/java/com/cn/cloudpictureplatform/application/outbox/OutboxProcessor.java
@@ -12,7 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.cn.cloudpictureplatform.domain.outbox.OutboxEvent;
 import com.cn.cloudpictureplatform.domain.outbox.OutboxStatus;
 import com.cn.cloudpictureplatform.infrastructure.persistence.OutboxEventRepository;
-import com.cn.cloudpictureplatform.websocket.NotificationPublisher;
+import com.cn.cloudpictureplatform.application.notification.NotificationPort;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,16 +22,16 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class OutboxProcessor {
     private final OutboxEventRepository outboxEventRepository;
-    private final NotificationPublisher notificationPublisher;
+    private final NotificationPort NotificationPort;
     private final ObjectMapper objectMapper;
 
     public OutboxProcessor(
             OutboxEventRepository outboxEventRepository,
-            NotificationPublisher notificationPublisher,
+            NotificationPort NotificationPort,
             ObjectMapper objectMapper
     ) {
         this.outboxEventRepository = outboxEventRepository;
-        this.notificationPublisher = notificationPublisher;
+        this.NotificationPort = NotificationPort;
         this.objectMapper = objectMapper;
     }
 
@@ -72,17 +72,17 @@ public class OutboxProcessor {
         switch (event.getEventType()) {
             case "UPLOAD_COMPLETE" -> {
                 String ownerUsername = payload.path("ownerUsername").asText();
-                notificationPublisher.notifyUploadCompleted(ownerUsername, pictureId, pictureName);
+                NotificationPort.notifyUploadCompleted(ownerUsername, pictureId, pictureName);
             }
             case "REVIEW_DECISION" -> {
                 String ownerUsername = payload.path("ownerUsername").asText();
                 boolean approved = payload.path("approved").asBoolean();
                 String reason = payload.path("reason").asText(null);
-                notificationPublisher.notifyReviewDecision(ownerUsername, pictureId, pictureName, approved, reason);
+                NotificationPort.notifyReviewDecision(ownerUsername, pictureId, pictureName, approved, reason);
             }
             case "ADMIN_NEW_UPLOAD" -> {
                 String uploaderUsername = payload.path("uploaderUsername").asText("unknown");
-                notificationPublisher.notifyAdminNewUpload(pictureId, pictureName, uploaderUsername);
+                NotificationPort.notifyAdminNewUpload(pictureId, pictureName, uploaderUsername);
             }
             case "TEAM_UPLOAD" -> {
                 Collection<String> usernames = new ArrayList<>();
@@ -93,7 +93,7 @@ public class OutboxProcessor {
                     }
                 }
                 String uploaderUsername = payload.path("uploaderUsername").asText("unknown");
-                notificationPublisher.notifyTeamPictureUploaded(usernames, pictureId, pictureName, uploaderUsername);
+                NotificationPort.notifyTeamPictureUploaded(usernames, pictureId, pictureName, uploaderUsername);
             }
             default -> log.warn("Unknown picture event type: {}", event.getEventType());
         }
@@ -109,11 +109,11 @@ public class OutboxProcessor {
             case "TEAM_INVITE" -> {
                 String inviterUsername = payload.path("inviterUsername").asText("unknown");
                 String inviteeUsername = payload.path("inviteeUsername").asText("unknown");
-                notificationPublisher.notifyTeamInvite(inviteeUsername, teamId, teamName, inviterUsername);
+                NotificationPort.notifyTeamInvite(inviteeUsername, teamId, teamName, inviterUsername);
             }
             case "TEAM_MEMBER_JOINED" -> {
                 String username = payload.path("username").asText("unknown");
-                notificationPublisher.notifyTeamMemberJoined(username, teamId, teamName);
+                NotificationPort.notifyTeamMemberJoined(username, teamId, teamName);
             }
             default -> log.warn("Unknown team event type: {}", event.getEventType());
         }

--- a/src/main/java/com/cn/cloudpictureplatform/application/picture/PictureCollaborationRoomService.java
+++ b/src/main/java/com/cn/cloudpictureplatform/application/picture/PictureCollaborationRoomService.java
@@ -4,7 +4,7 @@ import com.cn.cloudpictureplatform.common.web.ApiErrorCode;
 import com.cn.cloudpictureplatform.common.exception.ApiException;
 import com.cn.cloudpictureplatform.config.CollaborationProperties;
 import com.cn.cloudpictureplatform.config.JwtProperties;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.shared.dto.PictureCollaborationRoomResponse;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;

--- a/src/main/java/com/cn/cloudpictureplatform/application/team/TeamCommandService.java
+++ b/src/main/java/com/cn/cloudpictureplatform/application/team/TeamCommandService.java
@@ -22,7 +22,7 @@ import com.cn.cloudpictureplatform.infrastructure.persistence.SpaceRepository;
 import com.cn.cloudpictureplatform.infrastructure.persistence.TeamMemberEventRepository;
 import com.cn.cloudpictureplatform.infrastructure.persistence.TeamMemberRepository;
 import com.cn.cloudpictureplatform.infrastructure.persistence.TeamRepository;
-import com.cn.cloudpictureplatform.websocket.NotificationPublisher;
+import com.cn.cloudpictureplatform.application.notification.NotificationPort;
 import java.time.Instant;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -37,7 +37,7 @@ public class TeamCommandService {
     private final TeamMemberEventRepository teamMemberEventRepository;
     private final SpaceRepository spaceRepository;
     private final AppUserRepository appUserRepository;
-    private final NotificationPublisher notificationPublisher;
+    private final NotificationPort NotificationPort;
 
     public TeamCommandService(
             TeamRepository teamRepository,
@@ -45,14 +45,14 @@ public class TeamCommandService {
             TeamMemberEventRepository teamMemberEventRepository,
             SpaceRepository spaceRepository,
             AppUserRepository appUserRepository,
-            NotificationPublisher notificationPublisher
+            NotificationPort NotificationPort
     ) {
         this.teamRepository = teamRepository;
         this.teamMemberRepository = teamMemberRepository;
         this.teamMemberEventRepository = teamMemberEventRepository;
         this.spaceRepository = spaceRepository;
         this.appUserRepository = appUserRepository;
-        this.notificationPublisher = notificationPublisher;
+        this.NotificationPort = NotificationPort;
     }
 
     public TeamResponse createTeam(UUID ownerId, TeamCreateRequest request) {
@@ -125,7 +125,7 @@ public class TeamCommandService {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new ApiException(ApiErrorCode.NOT_FOUND, "team not found"));
         AppUser inviterUser = appUserRepository.findById(inviterId).orElse(null);
-        notificationPublisher.notifyTeamInvite(
+        NotificationPort.notifyTeamInvite(
                 invitee.getUsername(), teamId, team.getName(),
                 inviterUser == null ? "unknown" : inviterUser.getUsername());
         return toMemberResponse(savedMember, invitee);

--- a/src/main/java/com/cn/cloudpictureplatform/common/security/AppUserPrincipal.java
+++ b/src/main/java/com/cn/cloudpictureplatform/common/security/AppUserPrincipal.java
@@ -1,4 +1,4 @@
-package com.cn.cloudpictureplatform.infrastructure.security;
+package com.cn.cloudpictureplatform.common.security;
 
 import java.util.Collection;
 import java.util.Set;

--- a/src/main/java/com/cn/cloudpictureplatform/infrastructure/security/AppUserDetailsService.java
+++ b/src/main/java/com/cn/cloudpictureplatform/infrastructure/security/AppUserDetailsService.java
@@ -1,4 +1,5 @@
 package com.cn.cloudpictureplatform.infrastructure.security;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/com/cn/cloudpictureplatform/infrastructure/security/JwtTokenService.java
+++ b/src/main/java/com/cn/cloudpictureplatform/infrastructure/security/JwtTokenService.java
@@ -1,4 +1,5 @@
 package com.cn.cloudpictureplatform.infrastructure.security;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;

--- a/src/main/java/com/cn/cloudpictureplatform/infrastructure/security/WebSocketAuthChannelInterceptor.java
+++ b/src/main/java/com/cn/cloudpictureplatform/infrastructure/security/WebSocketAuthChannelInterceptor.java
@@ -1,4 +1,5 @@
 package com.cn.cloudpictureplatform.infrastructure.security;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 
 import java.util.HashSet;
 import java.util.List;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminPictureController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/admin/AdminPictureController.java
@@ -23,7 +23,7 @@ import com.cn.cloudpictureplatform.application.picture.ModerationService;
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.common.web.PageResponse;
 import com.cn.cloudpictureplatform.domain.picture.ReviewStatus;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.shared.dto.AdminPictureSummary;
 import com.cn.cloudpictureplatform.common.util.CsvUtil;
 import com.cn.cloudpictureplatform.application.shared.dto.ModerationRecordResponse;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/ai/AiAssistantController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/ai/AiAssistantController.java
@@ -10,7 +10,7 @@ import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.domain.ai.AiChatRequest;
 import com.cn.cloudpictureplatform.domain.ai.AiChatResponse;
 import com.cn.cloudpictureplatform.domain.ai.AiGateway;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 
 @RestController
 @RequestMapping("/api/v1/ai")

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/auth/AuthController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/auth/AuthController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.cn.cloudpictureplatform.application.auth.AuthService;
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.shared.dto.AuthResponse;
 import com.cn.cloudpictureplatform.application.shared.dto.LoginResponse;
 import com.cn.cloudpictureplatform.application.shared.dto.UserInfoResponse;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/developer/DeveloperController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/developer/DeveloperController.java
@@ -15,7 +15,7 @@ import com.cn.cloudpictureplatform.application.apikey.ApiKeyService;
 import com.cn.cloudpictureplatform.application.apikey.ApiKeyService.CreatedApiKey;
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.domain.apikey.ApiKey;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 
 @RestController
 @RequestMapping("/api/v1/developer/keys")

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/excalidraw/ExcalidrawSceneController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/excalidraw/ExcalidrawSceneController.java
@@ -2,7 +2,7 @@ package com.cn.cloudpictureplatform.interfaces.excalidraw;
 
 import com.cn.cloudpictureplatform.application.excalidraw.ExcalidrawSceneService;
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.shared.dto.CreateExcalidrawSceneRequest;
 import com.cn.cloudpictureplatform.application.shared.dto.ExcalidrawSceneResponse;
 import com.cn.cloudpictureplatform.interfaces.excalidraw.dto.UpdateSnapshotRequest;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/notification/NotificationController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/notification/NotificationController.java
@@ -14,7 +14,7 @@ import com.cn.cloudpictureplatform.application.notification.NotificationService;
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.common.web.PageResponse;
 import com.cn.cloudpictureplatform.domain.notification.NotificationRecord;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 
 @RestController
 @RequestMapping("/api/v1/notifications")

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/BatchPictureController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/BatchPictureController.java
@@ -2,7 +2,7 @@ package com.cn.cloudpictureplatform.interfaces.picture;
 
 import com.cn.cloudpictureplatform.application.picture.BatchPictureService;
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.interfaces.picture.dto.BatchOperationRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/DeduplicationPictureController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/DeduplicationPictureController.java
@@ -4,7 +4,7 @@ import com.cn.cloudpictureplatform.application.picture.DeduplicationPictureUploa
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.domain.picture.PictureAsset;
 import com.cn.cloudpictureplatform.domain.picture.Visibility;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.shared.dto.PictureResponse;
 import com.cn.cloudpictureplatform.interfaces.picture.dto.RapidUploadCheckResponse;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureCommentController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureCommentController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.cn.cloudpictureplatform.application.picture.PictureCommentService;
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.shared.dto.CommentCreateRequest;
 import com.cn.cloudpictureplatform.application.shared.dto.CommentResponse;
 

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureController.java
@@ -30,7 +30,7 @@ import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.common.web.PageResponse;
 import com.cn.cloudpictureplatform.domain.picture.ReviewStatus;
 import com.cn.cloudpictureplatform.domain.picture.Visibility;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.interfaces.picture.dto.EditorRealtimeEventDefinitionResponse;
 import com.cn.cloudpictureplatform.application.picture.dto.PictureTagCreateRequest;
 import com.cn.cloudpictureplatform.application.shared.dto.PictureDetailResponse;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureVersionController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/picture/PictureVersionController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import com.cn.cloudpictureplatform.application.picture.PictureVersionService;
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.shared.dto.PictureVersionResponse;
 
 @RestController

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/space/SpaceController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/space/SpaceController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.cn.cloudpictureplatform.application.space.SpaceQuotaService;
 import com.cn.cloudpictureplatform.application.space.SpaceQuotaService.SpaceUsageResponse;
 import com.cn.cloudpictureplatform.common.web.ApiResponse;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 
 @RestController
 @RequestMapping("/api/v1/spaces")

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/team/TeamController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/team/TeamController.java
@@ -27,7 +27,7 @@ import com.cn.cloudpictureplatform.domain.team.TeamMemberStatus;
 import com.cn.cloudpictureplatform.domain.team.TeamMemberEventType;
 import com.cn.cloudpictureplatform.domain.team.TeamRole;
 import com.cn.cloudpictureplatform.common.util.CsvUtil;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.team.dto.TeamCreateRequest;
 import com.cn.cloudpictureplatform.application.team.dto.TeamInviteRequest;
 import com.cn.cloudpictureplatform.application.team.dto.TeamInviteSummaryResponse;

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/watermark/WatermarkController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/watermark/WatermarkController.java
@@ -16,7 +16,7 @@ import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.domain.watermark.ExportPreset;
 import com.cn.cloudpictureplatform.domain.watermark.ExportTask;
 import com.cn.cloudpictureplatform.domain.watermark.WatermarkConfig;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.shared.dto.WatermarkConfigRequest;
 
 @RestController

--- a/src/main/java/com/cn/cloudpictureplatform/interfaces/webhook/WebhookController.java
+++ b/src/main/java/com/cn/cloudpictureplatform/interfaces/webhook/WebhookController.java
@@ -17,7 +17,7 @@ import com.cn.cloudpictureplatform.common.web.ApiResponse;
 import com.cn.cloudpictureplatform.common.web.PageResponse;
 import com.cn.cloudpictureplatform.domain.webhook.WebhookDelivery;
 import com.cn.cloudpictureplatform.domain.webhook.WebhookEndpoint;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 
 @RestController
 @RequestMapping("/api/v1/webhooks")

--- a/src/main/java/com/cn/cloudpictureplatform/websocket/NotificationPublisher.java
+++ b/src/main/java/com/cn/cloudpictureplatform/websocket/NotificationPublisher.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.UUID;
 
+import com.cn.cloudpictureplatform.application.notification.NotificationPort;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -12,7 +13,7 @@ import com.cn.cloudpictureplatform.websocket.dto.CollabMessage;
 import com.cn.cloudpictureplatform.websocket.dto.NotificationMessage;
 
 @Service
-public class NotificationPublisher {
+public class NotificationPublisher implements NotificationPort {
     private final SimpMessagingTemplate messagingTemplate;
     private final ObjectMapper objectMapper;
 

--- a/src/test/java/com/cn/cloudpictureplatform/application/team/TeamServiceTests.java
+++ b/src/test/java/com/cn/cloudpictureplatform/application/team/TeamServiceTests.java
@@ -27,7 +27,7 @@ import com.cn.cloudpictureplatform.infrastructure.persistence.TeamMemberReposito
 import com.cn.cloudpictureplatform.infrastructure.persistence.TeamRepository;
 import com.cn.cloudpictureplatform.application.team.dto.TeamInviteRequest;
 import com.cn.cloudpictureplatform.application.team.dto.TeamSummaryResponse;
-import com.cn.cloudpictureplatform.websocket.NotificationPublisher;
+import com.cn.cloudpictureplatform.application.notification.NotificationPort;
 
 @ExtendWith(MockitoExtension.class)
 class TeamServiceTests {
@@ -43,7 +43,7 @@ class TeamServiceTests {
     @Mock
     private AppUserRepository appUserRepository;
     @Mock
-    private NotificationPublisher notificationPublisher;
+    private NotificationPort notificationPort;
 
     private TeamCommandService teamCommandService;
     private TeamQueryService teamQueryService;
@@ -56,7 +56,7 @@ class TeamServiceTests {
                 teamMemberEventRepository,
                 spaceRepository,
                 appUserRepository,
-                notificationPublisher
+                notificationPort
         );
         teamQueryService = new TeamQueryService(
                 teamRepository,
@@ -116,7 +116,7 @@ class TeamServiceTests {
         teamCommandService.inviteMember(teamId, inviterId, request);
 
         verify(teamMemberEventRepository).save(any(TeamMemberEvent.class));
-        verify(notificationPublisher).notifyTeamInvite("bob", teamId, "Design Team", "alice");
+        verify(notificationPort).notifyTeamInvite("bob", teamId, "Design Team", "alice");
     }
 
     @Test

--- a/src/test/java/com/cn/cloudpictureplatform/interfaces/picture/PictureControllerTests.java
+++ b/src/test/java/com/cn/cloudpictureplatform/interfaces/picture/PictureControllerTests.java
@@ -11,7 +11,7 @@ import com.cn.cloudpictureplatform.application.picture.PictureDocumentService;
 import com.cn.cloudpictureplatform.application.picture.PictureCollaborationRoomService;
 import com.cn.cloudpictureplatform.application.shared.dto.PictureCollaborationRoomResponse;
 import com.cn.cloudpictureplatform.domain.user.UserRole;
-import com.cn.cloudpictureplatform.infrastructure.security.AppUserPrincipal;
+import com.cn.cloudpictureplatform.common.security.AppUserPrincipal;
 import com.cn.cloudpictureplatform.application.shared.dto.PictureEditorDocumentResponse;
 import com.cn.cloudpictureplatform.interfaces.picture.dto.PictureEditorSessionResponse;
 import com.cn.cloudpictureplatform.websocket.EditLockPort;


### PR DESCRIPTION
## 改动
- 27 files changed, +62 / -39 lines
- 26 tests passing

### NotificationPort (fix application → websocket)
- 创建 NotificationPort 接口 (application.notification)
- NotificationPublisher 实现 NotificationPort
- OutboxProcessor/TeamCommandService 依赖 Port 而非 websocket 实现

### AppUserPrincipal (fix interfaces → infrastructure)
- AppUserPrincipal: infrastructure.security → common.security
- 18 个文件 import 更新

### ArchUnit 验证
原有 4 条 domain 独立性规则全部通过。application → websocket 和 interfaces → infrastructure 违规已消除。

Closes #26